### PR TITLE
RetVoid instructions

### DIFF
--- a/src/IRBuilder/Monad.hs
+++ b/src/IRBuilder/Monad.hs
@@ -156,6 +156,17 @@ emitInstr retty instr = do
     }
   pure (LocalReference retty nm)
 
+-- | Emit instruction that returns void
+emitInstrVoid
+  :: MonadIRBuilder m
+  => Instruction
+  -> m ()
+emitInstrVoid instr = do
+  modifyBlock $ \bb -> bb
+    { partialBlockInstrs = partialBlockInstrs bb `snoc` (Do instr)
+    }
+  pure ()
+
 -- | Emit terminator
 emitTerm
   :: MonadIRBuilder m


### PR DESCRIPTION
Adds emitter for instructions that don't return a named operand. I.e. calling functions with void return times or invoking intrinsics.