### PR TITLE
Blocks without recursive do

### DIFF
--- a/src/ModuleBuilder.hs
+++ b/src/ModuleBuilder.hs
@@ -142,15 +142,15 @@ extern
   -> [Type] -- ^ Parametere types
   -> Type   -- ^ Type
   -> m Operand
-extern name argtys retty = do
+extern nm argtys retty = do
   emitDefn $ GlobalDefinition functionDefaults
-    { name        = name
+    { name        = nm
     , linkage     = External
     , parameters  = ([Parameter ty (mkName "") [] | ty <- argtys], False)
     , returnType  = retty
     }
   let funty = FunctionType retty argtys False
-  pure $ ConstantOperand $ C.GlobalReference funty name
+  pure $ ConstantOperand $ C.GlobalReference funty nm
 
 -- | A named type definition
 typedef
@@ -164,15 +164,15 @@ typedef nm ty = do
 
 -- | Convenience function for module construction
 buildModule :: ShortByteString -> ModuleBuilder a -> Module
-buildModule name = mkModule . execModuleBuilder emptyModuleBuilder
+buildModule nm = mkModule . execModuleBuilder emptyModuleBuilder
   where
-    mkModule ds = defaultModule { moduleName = name, moduleDefinitions = ds }
+    mkModule ds = defaultModule { moduleName = nm, moduleDefinitions = ds }
 
 -- | Convenience function for module construction (transformer version)
 buildModuleT :: Monad m => ShortByteString -> ModuleBuilderT m a -> m Module
-buildModuleT name = fmap mkModule . execModuleBuilderT emptyModuleBuilder
+buildModuleT nm = fmap mkModule . execModuleBuilderT emptyModuleBuilder
   where
-    mkModule ds = defaultModule { moduleName = name, moduleDefinitions = ds }
+    mkModule ds = defaultModule { moduleName = nm, moduleDefinitions = ds }
 
 -------------------------------------------------------------------------------
 -- mtl instances


### PR DESCRIPTION
 Adds an `emitBlockStart` function which makes it possible to create recursive blocks without using
`RecursiveDo`.

`emitBlockStart` is a low-level function that emits a block using a
given name (assumed to be fresh), which means that the user can manually
use `freshName` to create a block name that can be used before the block
is emitted.

The reason for not always wanting `RecursiveDo` is that it's sometimes
difficult or unclear how to make your code lazy enough for it to be able
to work, which can lead to crashes and infinite loops that are difficult
to diagnose.