### PR TITLE
Remove dependency on llvm-pretty from the test suite

### DIFF
--- a/irbuilder.cabal
+++ b/irbuilder.cabal
@@ -1,6 +1,8 @@
--- This file has been generated from package.yaml by hpack version 0.17.1.
+-- This file has been generated from package.yaml by hpack version 0.20.0.
 --
 -- see: https://github.com/sol/hpack
+--
+-- hash: 8246c14e241453cb7760dc01cfcb2c1303a48d44110c7d222e0e820ef45019c6
 
 name:           irbuilder
 version:        0.1.0.0
@@ -16,20 +18,20 @@ library
   ghc-options: -fwarn-incomplete-patterns
   build-depends:
       base >=4.9 && <4.11
-    , transformers
-    , mtl
     , bytestring
-    , text
     , containers
-    , unordered-containers
-    , llvm-hs-pure
     , llvm-hs-pretty
+    , llvm-hs-pure
+    , mtl
+    , text
+    , transformers
+    , unordered-containers
   exposed-modules:
-      IRBuilder
-      IRBuilder.Monad
-      IRBuilder.Instruction
-      ModuleBuilder
-      Util.SnocList
+      LLVM.IRBuilder
+      LLVM.IRBuilder.Instruction
+      LLVM.IRBuilder.Monad
+      LLVM.IRBuilder.Module
+      LLVM.IRBuilder.Internal.SnocList
   other-modules:
       Paths_irbuilder
   default-language: Haskell2010
@@ -41,14 +43,16 @@ test-suite irbuilder
       test
   build-depends:
       base >=4.9 && <4.11
-    , transformers
-    , mtl
     , bytestring
-    , text
     , containers
-    , unordered-containers
-    , llvm-hs-pure
-    , llvm-hs-pretty
     , hspec
     , irbuilder
+    , llvm-hs-pretty
+    , llvm-hs-pure
+    , mtl
+    , text
+    , transformers
+    , unordered-containers
+  other-modules:
+      Paths_irbuilder
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -17,11 +17,11 @@ library:
   ghc-options:
     -fwarn-incomplete-patterns
   exposed-modules:
-  - IRBuilder
-  - IRBuilder.Monad
-  - IRBuilder.Instruction
-  - ModuleBuilder
-  - Util.SnocList
+  - LLVM.IRBuilder
+  - LLVM.IRBuilder.Instruction
+  - LLVM.IRBuilder.Monad
+  - LLVM.IRBuilder.Module
+  - LLVM.IRBuilder.Internal.SnocList
 tests:
   irbuilder:
     source-dirs: test

--- a/src/IRBuilder.hs
+++ b/src/IRBuilder.hs
@@ -1,7 +1,0 @@
-module IRBuilder
-  (module X)
-  where
-
-import IRBuilder.Monad as X
-import IRBuilder.Instruction as X
-import ModuleBuilder as X

--- a/src/LLVM/IRBuilder.hs
+++ b/src/LLVM/IRBuilder.hs
@@ -1,0 +1,7 @@
+module LLVM.IRBuilder
+  (module X)
+  where
+
+import LLVM.IRBuilder.Monad as X
+import LLVM.IRBuilder.Instruction as X
+import LLVM.IRBuilder.Module as X

--- a/src/LLVM/IRBuilder/Instruction.hs
+++ b/src/LLVM/IRBuilder/Instruction.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 
-module IRBuilder.Instruction where
+module LLVM.IRBuilder.Instruction where
 
 import Prelude hiding (and, or, pred)
 
@@ -16,7 +16,7 @@ import qualified LLVM.AST.Constant as C
 import qualified LLVM.AST.IntegerPredicate as IP
 import qualified LLVM.AST.FloatingPointPredicate as FP
 
-import IRBuilder.Monad
+import LLVM.IRBuilder.Monad
 
 fadd :: MonadIRBuilder m => Operand -> Operand -> m Operand
 fadd a b = emitInstr (typeOf a) $ FAdd NoFastMathFlags a b []

--- a/src/LLVM/IRBuilder/Internal/SnocList.hs
+++ b/src/LLVM/IRBuilder/Internal/SnocList.hs
@@ -1,4 +1,4 @@
-module Util.SnocList where
+module LLVM.IRBuilder.Internal.SnocList where
 
 newtype SnocList a = SnocList { unSnocList :: [a] }
   deriving (Eq, Show)

--- a/src/LLVM/IRBuilder/Module.hs
+++ b/src/LLVM/IRBuilder/Module.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-} -- For MonadState s (IRBuilderT m) instance
 
-module ModuleBuilder where
+module LLVM.IRBuilder.Module where
 
 import Prelude hiding (and, or)
 
@@ -41,8 +41,8 @@ import LLVM.AST.Global
 import LLVM.AST.Linkage
 import qualified LLVM.AST.Constant as C
 
-import Util.SnocList
-import IRBuilder.Monad
+import LLVM.IRBuilder.Internal.SnocList
+import LLVM.IRBuilder.Monad
 
 newtype ModuleBuilderT m a = ModuleBuilderT { unModuleBuilderT :: StateT ModuleBuilderState m a }
   deriving

--- a/src/LLVM/IRBuilder/Monad.hs
+++ b/src/LLVM/IRBuilder/Monad.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-} -- For MonadState s (ModuleBuilderT m) instance
 
-module IRBuilder.Monad where
+module LLVM.IRBuilder.Monad where
 
 import Prelude hiding (and, or)
 
@@ -34,7 +34,7 @@ import qualified Data.HashSet as HS
 
 import LLVM.AST
 
-import Util.SnocList
+import LLVM.IRBuilder.Internal.SnocList
 
 -- | This provides a uniform API for creating instructions and inserting them
 -- into a basic block: either at the end of a BasicBlock, or at a specific

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -14,9 +14,7 @@ import           LLVM.AST.Type as AST
 import           LLVM.Pretty (ppllvm)
 import           Test.Hspec hiding (example)
 
-import           IRBuilder.Instruction
-import           IRBuilder.Monad
-import           ModuleBuilder
+import           LLVM.IRBuilder
 
 main :: IO ()
 main =


### PR DESCRIPTION
A dependency on `llvm-hs-pretty` would lead to a cyclic dependency once we merge `llvm-irbuilder` into `llvm-hs-pure`.

This only removes the dependency from the test suite, the actual package still depends on `llvm-hs-pretty` until https://github.com/llvm-hs/llvm-hs/pull/156 is merged.

I based this on #18 since it would conflict and I might as well fix the conflict upfront. Obviously this means that #18 should be merged first.