### PR TITLE
Add a constant module

### DIFF
--- a/irbuilder.cabal
+++ b/irbuilder.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0538ae9ce3c9686975959296b931edd7be596063e7633b4381a8d1ef33294e90
+-- hash: e37dce2442cb5016db44897609b99ebbd2b8eb8f975f9b3c679fe42b26c42fb5
 
 name:           irbuilder
 version:        0.1.0.0
@@ -28,6 +28,7 @@ library
   exposed-modules:
       LLVM.IRBuilder
       LLVM.IRBuilder.Instruction
+      LLVM.IRBuilder.Constant
       LLVM.IRBuilder.Monad
       LLVM.IRBuilder.Module
       LLVM.IRBuilder.Internal.SnocList

--- a/package.yaml
+++ b/package.yaml
@@ -18,6 +18,7 @@ library:
   exposed-modules:
   - LLVM.IRBuilder
   - LLVM.IRBuilder.Instruction
+  - LLVM.IRBuilder.Constant
   - LLVM.IRBuilder.Monad
   - LLVM.IRBuilder.Module
   - LLVM.IRBuilder.Internal.SnocList

--- a/src/LLVM/IRBuilder/Constant.hs
+++ b/src/LLVM/IRBuilder/Constant.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module LLVM.IRBuilder.Constant where
+import Data.Word
+
+import qualified LLVM.AST.Constant as C
+import LLVM.AST.Type as AST
+import LLVM.IRBuilder.Monad
+import LLVM.AST hiding (args, dests)
+
+import LLVM.AST.Constant
+import LLVM.AST.Float
+
+int64 :: MonadIRBuilder m => Integer -> m Operand
+int64 = pure . ConstantOperand . Int 64
+
+double :: MonadIRBuilder m => Double -> m Operand
+double = pure . ConstantOperand . Float . Double
+
+single :: MonadIRBuilder m => Float -> m Operand
+single = pure . ConstantOperand . Float . Single
+
+half :: MonadIRBuilder m => Word16 -> m Operand
+half = pure . ConstantOperand . Float . Half
+


### PR DESCRIPTION
I wanted to use this for code generation but I realized there was no mechanism to generate constant operands. 

For now the module just has helpers for basic numerical types, I think it's pretty reasonable to expand this to arrays and structs but should this cover all the constant values?